### PR TITLE
Done#54634 django:auth_permissions: skip creation of auth permissions…

### DIFF
--- a/django/contrib/auth/management/__init__.py
+++ b/django/contrib/auth/management/__init__.py
@@ -94,6 +94,12 @@ def create_permissions(app, created_models, verbosity, db=DEFAULT_DB_ALIAS, **kw
         for ctype, (codename, name) in searched_perms
         if (ctype.pk, codename) not in all_perms
     ]
+    
+    # Reference ticket:
+    # https://elasticainc.assembla.com/spaces/elastica/tickets/54634/details
+    # We do not use the auth/permission system of django hence not creating these perms is safe for us
+    return
+
     auth_app.Permission.objects.using(db).bulk_create(perms)
     if verbosity >= 2:
         for perm in perms:


### PR DESCRIPTION
… as we do not use these in our system and they mess up our migration procesure scripts