### PR TITLE
Done #80257: Support for multiple secret keys

### DIFF
--- a/django/contrib/sessions/backends/el_db.py
+++ b/django/contrib/sessions/backends/el_db.py
@@ -1,0 +1,60 @@
+"""
+Elastica's Implementation of db base session store.
+"""
+
+import base64
+
+from django.core.exceptions import SuspiciousOperation
+from django.conf import settings
+from django.contrib.sessions.backends.db import SessionStore as DjangoDBSessionStore
+from django.utils.crypto import constant_time_compare, salted_hmac
+from django.utils.encoding import force_bytes
+
+
+class SessionStore(DjangoDBSessionStore):
+    """
+    Implements database session store for Elastica.
+
+    The additional features in this session store implementation are:
+    - Able to decode session data using mutliple keys. Note that we don't need to change encode
+    function as we'll always encode with latest available key. For decode, however, if we are
+    unable to decode with latest key, we'll try rest of the configured keys and only throw error
+    if everythin fails.
+    """
+
+    def _hash(self, value, secret=None, class_name="SessionStore"):
+        key_salt = "django.contrib.sessions" + class_name
+        return salted_hmac(key_salt, value, secret).hexdigest()
+
+    def decode(self, session_data):
+        encoded_data = base64.b64decode(force_bytes(session_data))
+        try:
+            # could produce ValueError if there is no ':'
+            hash_val, serialized = encoded_data.split(b':', 1)
+            # If there's only a single key, use just that
+            if not getattr(settings, "SESSION_ENCRYPTION_KEYS", None) or len(settings.SESSION_ENCRYPTION_KEYS) == 1:
+                return self._decode_with_single_key(hash_val, serialized)
+            # If multiple keys are there, try all of them
+            return self._decode_with_multiple_keys(hash_val, serialized)
+        except Exception:
+            # ValueError, SuspiciousOperation, deserialization exceptions. If
+            # any of these happen, just return an empty dictionary (an empty
+            # session).
+            return {}
+
+    def _decode_with_single_key(self, hash_val, serialized):
+        expected_hash = self._hash(serialized)
+        if not constant_time_compare(hash_val.decode(), expected_hash):
+            raise SuspiciousOperation("Session data corrupted")
+
+        return self.serializer().loads(serialized)
+
+    def _decode_with_multiple_keys(self, hash_val, serialized):
+        for key in settings.SESSION_ENCRYPTION_KEYS:
+            expected_hash = self._hash(serialized, secret=key)
+            if not constant_time_compare(hash_val.decode(), expected_hash):
+                continue
+            # If here, that means session got decoded
+            return self.serializer().loads(serialized)
+        # If here, then we've exhausted all the keys, raise Exception
+        raise SuspiciousOperation("Session data corrupted")

--- a/django/contrib/sessions/tests.py
+++ b/django/contrib/sessions/tests.py
@@ -7,6 +7,7 @@ import warnings
 
 from django.conf import settings
 from django.contrib.sessions.backends.db import SessionStore as DatabaseSession
+from django.contrib.sessions.backends.el_db import SessionStore as ElDatabaseSession
 from django.contrib.sessions.backends.cache import SessionStore as CacheSession
 from django.contrib.sessions.backends.cached_db import SessionStore as CacheDBSession
 from django.contrib.sessions.backends.file import SessionStore as FileSession
@@ -572,3 +573,37 @@ class CookieSessionTests(SessionTestsMixin, TestCase):
     def test_actual_expiry(self):
         # The cookie backend doesn't handle non-default expiry dates, see #19201
         super(CookieSessionTests, self).test_actual_expiry()
+
+
+class ElDatabaseSessionTests(DatabaseSessionTests):
+
+    backend = ElDatabaseSession
+
+    @override_settings(SECRET_KEY="old_key", SESSION_ENCRYPTION_KEYS=["old_key"])
+    def test_rotation(self):
+        # Ensure that rotation won't logout already existing sessions
+        data = {'a test key': 'a test value'}
+        encoded = self.session.encode(data)
+        with override_settings(SECRET_KEY="new_key", SESSION_ENCRYPTION_KEYS=["new_key", "old_key"]):
+            self.assertEqual(self.session.decode(encoded), data)
+
+    @override_settings(SECRET_KEY="old_key", SESSION_ENCRYPTION_KEYS=["new_key", "old_key"])
+    def test_rotation_decode(self):
+        # Ensure we can decode sessions encoded with old keys
+        data = {'a test key': 'a test value'}
+        encoded = self.session.encode(data)
+        self.assertEqual(self.session.decode(encoded), data)
+
+    @override_settings(SECRET_KEY="old_key", SESSION_ENCRYPTION_KEYS=["new_key", "bad_old_key"])
+    def test_failed_rotation_decode(self):
+        # Ensure we cannot decode sessions when old key isn't available anymore
+        data = {'a test key': 'a test value'}
+        encoded = self.session.encode(data)
+        self.assertNotEqual(self.session.decode(encoded), data)
+
+    @override_settings(SECRET_KEY="old_key", SESSION_ENCRYPTION_KEYS=["old_key"])
+    def test_single_key_decode(self):
+        # Ensure we can decode sessions when only a single key is configured
+        data = {'a test key': 'a test value'}
+        encoded = self.session.encode(data)
+        self.assertEqual(self.session.decode(encoded), data)


### PR DESCRIPTION
### Description
- Added support for multiple secret keys. i.e. Fall back to old keys if unable to decrypt with the new key.

### Ticket
- Ticket link: [#80257](https://elasticainc.assembla.com/spaces/elastica/tickets/80257)

### Tests performed (UT)
Written automated tests and ran all the session test cases. [Passed, except for 1 expected failure]